### PR TITLE
Add `AttestationType`, check during verify

### DIFF
--- a/src/pypi_attestations/_impl.py
+++ b/src/pypi_attestations/_impl.py
@@ -6,7 +6,7 @@ This module is NOT a public API, and is not considered stable.
 from __future__ import annotations
 
 import base64
-from enum import StrEnum
+from enum import Enum
 from typing import TYPE_CHECKING, Annotated, Any, Literal, NewType
 
 import sigstore.errors
@@ -38,7 +38,7 @@ if TYPE_CHECKING:
     from sigstore.verify.policy import VerificationPolicy  # pragma: no cover
 
 
-class AttestationType(StrEnum):
+class AttestationType(str, Enum):
     """Attestation types known to PyPI."""
 
     SLSA_PROVENANCE_V1 = "https://slsa.dev/provenance/v1"

--- a/src/pypi_attestations/_impl.py
+++ b/src/pypi_attestations/_impl.py
@@ -127,7 +127,7 @@ class Attestation(BaseModel):
                         )
                     ]
                 )
-                .predicate_type(AttestationType.SLSA_PROVENANCE_V1)
+                .predicate_type(AttestationType.PYPI_PUBLISH_V1)
                 .build()
             )
         except DsseError as e:

--- a/src/pypi_attestations/_impl.py
+++ b/src/pypi_attestations/_impl.py
@@ -194,6 +194,11 @@ class Attestation(BaseModel):
         if digest is None or digest != expected_digest:
             raise VerificationError("subject does not match distribution digest")
 
+        try:
+            AttestationType(statement.predicate_type)
+        except ValueError:
+            raise VerificationError(f"unknown attestation type: {statement.predicate_type}")
+
         return statement.predicate_type, statement.predicate
 
     def to_bundle(self) -> Bundle:

--- a/src/pypi_attestations/_impl.py
+++ b/src/pypi_attestations/_impl.py
@@ -6,6 +6,7 @@ This module is NOT a public API, and is not considered stable.
 from __future__ import annotations
 
 import base64
+from enum import StrEnum
 from typing import TYPE_CHECKING, Annotated, Any, Literal, NewType
 
 import sigstore.errors
@@ -35,6 +36,13 @@ if TYPE_CHECKING:
     from sigstore.sign import Signer  # pragma: no cover
     from sigstore.verify import Verifier  # pragma: no cover
     from sigstore.verify.policy import VerificationPolicy  # pragma: no cover
+
+
+class AttestationType(StrEnum):
+    """Attestation types known to PyPI."""
+
+    SLSA_PROVENANCE_V1 = "https://slsa.dev/provenance/v1"
+    PYPI_PUBLISH_V1 = "https://docs.pypi.org/attestations/publish/v1"
 
 
 class AttestationError(ValueError):
@@ -119,7 +127,7 @@ class Attestation(BaseModel):
                         )
                     ]
                 )
-                .predicate_type("https://docs.pypi.org/attestations/publish/v1")
+                .predicate_type(AttestationType.SLSA_PROVENANCE_V1)
                 .build()
             )
         except DsseError as e:

--- a/test/test_impl.py
+++ b/test/test_impl.py
@@ -319,7 +319,9 @@ class TestAttestation:
                         name="rfc8785-0.1.2-py3-none-any.whl",
                         digest=_DigestSet(
                             root={
-                                "sha256": "c4e92e9ecc828bef2aa7dba1de8ac983511f7532a0df11c770d39099a25cf201"
+                                "sha256": (
+                                    "c4e92e9ecc828bef2aa7dba1de8ac983511f7532a0df11c770d39099a25cf201"
+                                ),
                             }
                         ),
                     ),


### PR DESCRIPTION
This ratchets verification down slightly: we reject the payload even if signed if it doesn't match one of our known attestation types, rather than expecting the caller to check the attestation type.

The caller can still further filter verification, e.g. by rejecting attestation types known to `pypi-attestations` but not supported by the caller.

WIP; needs tests.