### PR TITLE
Upgrade minimum Python version

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -11,8 +11,6 @@ jobs:
     strategy:
       matrix:
         python:
-          - "3.9"
-          - "3.10"
           - "3.11"
           - "3.12"
     runs-on: ubuntu-latest

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- The minimum Python version required has been bumped to `3.11`
+  ([#37](https://github.com/trailofbits/pypi-attestations/pull/37))
+
 ## [0.0.9]
 
 ### Added

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,7 @@ dependencies = [
     "sigstore~=3.0.0",
     "sigstore-protobuf-specs",
 ]
-requires-python = ">=3.9"
+requires-python = ">=3.11"
 
 [project.optional-dependencies]
 doc = ["pdoc"]
@@ -75,7 +75,7 @@ warn_unused_ignores = true
 
 [tool.ruff]
 line-length = 100
-target-version = "py39"
+target-version = "py311"
 
 [tool.ruff.lint]
 select = ["E", "F", "I", "W", "UP", "ANN", "D", "COM", "ISC", "TCH", "SLF"]


### PR DESCRIPTION
Upgrade the minimum Python version to `3.11`.

Of note, `warehouse` is on [3.12](https://github.com/pypi/warehouse/blob/main/.python-version) so we could safely also require `3.12`. WDYT?