### PR TITLE
misc cleanup

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,3 @@
-[build-system]
-requires = ["flit_core >=3.5,<4"]
-build-backend = "flit_core.buildapi"
-
 [project]
 name = "pypi-attestations"
 dynamic = ["version"]
@@ -17,10 +13,13 @@ dependencies = [
     "cryptography",
     "packaging",
     "pydantic",
-    "sigstore~=3.2",
+    "sigstore~=3.3",
     "sigstore-protobuf-specs",
 ]
 requires-python = ">=3.11"
+
+[tool.setuptools.dynamic]
+version = { attr = "pypi_attestations.__version__" }
 
 [project.optional-dependencies]
 doc = ["pdoc"]

--- a/test/test_impl.py
+++ b/test/test_impl.py
@@ -537,7 +537,7 @@ class TestProvenance:
             )
 
 
-class TestModel(BaseModel):
+class DummyModel(BaseModel):
     base64_bytes: impl.Base64Bytes
 
 
@@ -547,8 +547,8 @@ class TestBase64Bytes:
         # This raises when using our custom type. When using Pydantic's Base64Bytes,
         # this succeeds
         with pytest.raises(ValueError, match="Only base64 data is allowed"):
-            TestModel(base64_bytes=b"a\n\naaa")
+            DummyModel(base64_bytes=b"a\n\naaa")
 
     def test_encoding(self) -> None:
-        model = TestModel(base64_bytes=b"aaaa" * 76)
+        model = DummyModel(base64_bytes=b"aaaa" * 76)
         assert "\\n" not in model.model_dump_json()


### PR DESCRIPTION
* Uses the default build backend
* Renames TestModel -> DummyModel (fixes pytest confusion)
* Bumps sigstore to ~3.3