### PR TITLE
Mix fixes and prep release for `0.0.17`

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,6 +34,23 @@ jobs:
           name: distributions
           path: dist/
 
+  generate-provenance:
+    name: Generate GitHub build provenances
+    runs-on: ubuntu-latest
+    needs: [build]
+    permissions:
+      id-token: write # to sign the provenance
+      attestations: write # to persist the attestation files
+    steps:
+      - name: Download distributions
+        uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16 # v4
+        with:
+          name: distributions
+          path: dist/
+      - name: Create provenances
+        uses: actions/attest-build-provenance@v1
+        with:
+          subject-path: 'dist/*'
 
   publish:
     name: Publish Python 🐍 distributions 📦 to PyPI

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -185,7 +185,7 @@ This is a corrective release for [0.0.14].
 - Initial implementation
 
 [Unreleased]: https://github.com/trailofbits/pypi-attestation-models/compare/v0.0.16...HEAD
-[0.0.16]: https://github.com/trailofbits/pypi-attestation-models/compare/v0.0.15...v0.0.15
+[0.0.16]: https://github.com/trailofbits/pypi-attestation-models/compare/v0.0.15...v0.0.16
 [0.0.15]: https://github.com/trailofbits/pypi-attestation-models/compare/v0.0.14...v0.0.15
 [0.0.14]: https://github.com/trailofbits/pypi-attestation-models/compare/v0.0.13...v0.0.14
 [0.0.13]: https://github.com/trailofbits/pypi-attestation-models/compare/v0.0.12...v0.0.13

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.0.17]
+
 ### Fixed
 
 - The `GitLabPublisher` policy now takes the workflow file path in order to
@@ -16,6 +18,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   rather the `ref` and `sha` claims are extracted from the certificate's extensions,
   similar to `GitHubPublisher`'s behavior
   ([#71](https://github.com/trailofbits/pypi-attestations/pull/71)).
+
+
+### Changed
+
+- Publisher classes (`GitLabPublisher` and `GitHubPublisher`) no longer take a claims
+  dictionary during construction
+  ([#72](https://github.com/trailofbits/pypi-attestations/pull/72)).
 
 ## [0.0.16]
 
@@ -184,7 +193,8 @@ This is a corrective release for [0.0.14].
 
 - Initial implementation
 
-[Unreleased]: https://github.com/trailofbits/pypi-attestation-models/compare/v0.0.16...HEAD
+[Unreleased]: https://github.com/trailofbits/pypi-attestation-models/compare/v0.0.17...HEAD
+[0.0.17]: https://github.com/trailofbits/pypi-attestation-models/compare/v0.0.16...v0.0.17
 [0.0.16]: https://github.com/trailofbits/pypi-attestation-models/compare/v0.0.15...v0.0.16
 [0.0.15]: https://github.com/trailofbits/pypi-attestation-models/compare/v0.0.14...v0.0.15
 [0.0.14]: https://github.com/trailofbits/pypi-attestation-models/compare/v0.0.13...v0.0.14

--- a/src/pypi_attestations/__init__.py
+++ b/src/pypi_attestations/__init__.py
@@ -1,6 +1,6 @@
 """The `pypi-attestations` APIs."""
 
-__version__ = "0.0.16"
+__version__ = "0.0.17"
 
 from ._impl import (
     Attestation,

--- a/src/pypi_attestations/_impl.py
+++ b/src/pypi_attestations/_impl.py
@@ -406,7 +406,6 @@ class _PublisherBase(BaseModel):
     model_config = ConfigDict(alias_generator=to_snake)
 
     kind: str
-    claims: Optional[dict[str, Any]] = None
 
     def _as_policy(self) -> VerificationPolicy:
         """Return an appropriate `sigstore.policy.VerificationPolicy` for this publisher."""

--- a/test/test_impl.py
+++ b/test/test_impl.py
@@ -4,7 +4,7 @@ import json
 import os
 from hashlib import sha256
 from pathlib import Path
-from typing import Any, Optional
+from typing import Any
 
 import pretend
 import pytest
@@ -136,12 +136,10 @@ class TestAttestation:
         assert predicate_type == "https://docs.pypi.org/attestations/publish/v1"
         assert predicate == {}
 
-    @pytest.mark.parametrize("claims", (None, {}, {"ref": "refs/tags/v0.0.4a2"}))
-    def test_verify_from_github_publisher(self, claims: Optional[dict]) -> None:
+    def test_verify_from_github_publisher(self) -> None:
         publisher = impl.GitHubPublisher(
             repository="trailofbits/pypi-attestation-models",
             workflow="release.yml",
-            claims=claims,
         )
 
         bundle = Bundle.from_json(gh_signed_dist_bundle_path.read_bytes())
@@ -585,23 +583,6 @@ class TestPublisher:
 
         with pytest.raises(ValueError, match="Input should be 'GitLab'"):
             impl.GitLabPublisher(kind="GitHub", repository="foo/bar")
-
-    def test_claims(self) -> None:
-        raw = {
-            "kind": "GitHub",
-            "repository": "foo/bar",
-            "workflow": "publish.yml",
-            "claims": {
-                "this": "is-preserved",
-                "this-too": 123,
-            },
-        }
-        pub: impl.Publisher = TypeAdapter(impl.Publisher).validate_python(raw)
-
-        assert pub.claims == {
-            "this": "is-preserved",
-            "this-too": 123,
-        }
 
 
 class TestProvenance:


### PR DESCRIPTION
This PR:
- Removes the `claims` field from the Publishers, since it's no longer used
- Adds a step to the release GHA workflow to generate GH provenances
- Bumps the version to `0.0.17` and updates the changelog