### PR TITLE
Bump pydantic to 2.10.0 and remove Base64 workaround

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ dependencies = [
     "cryptography",
     "packaging",
     "pyasn1 ~= 0.6",
-    "pydantic",
+    "pydantic >= 2.10.0",
     "sigstore~=3.4",
     "sigstore-protobuf-specs",
 ]

--- a/src/pypi_attestations/_impl.py
+++ b/src/pypi_attestations/_impl.py
@@ -17,7 +17,7 @@ from cryptography.hazmat.primitives import serialization
 from packaging.utils import parse_sdist_filename, parse_wheel_filename
 from pyasn1.codec.der.decoder import decode as der_decode
 from pyasn1.type.char import UTF8String
-from pydantic import Base64Encoder, BaseModel, ConfigDict, EncodedBytes, Field, field_validator
+from pydantic import Base64Bytes, BaseModel, ConfigDict, Field, field_validator
 from pydantic.alias_generators import to_snake
 from pydantic_core import ValidationError
 from sigstore._utils import _sha256_streaming
@@ -36,30 +36,6 @@ if TYPE_CHECKING:  # pragma: no cover
     from cryptography.x509 import Certificate
     from sigstore.sign import Signer
     from sigstore.verify.policy import VerificationPolicy
-
-
-class Base64EncoderSansNewline(Base64Encoder):
-    r"""A Base64Encoder that doesn't insert newlines when encoding.
-
-    Pydantic's Base64Bytes type inserts newlines b'\n' every 76 characters because they
-    use `base64.encodebytes()` instead of `base64.b64encode()`. Pydantic maintainers
-    have stated that they won't fix this, and that users should work around it by
-    defining their own Base64 type with a custom encoder.
-    See https://github.com/pydantic/pydantic/issues/9072 for more details.
-    """
-
-    @classmethod
-    def encode(cls, value: bytes) -> bytes:
-        """Encode bytes to base64."""
-        return base64.b64encode(value)
-
-    @classmethod
-    def decode(cls, value: bytes) -> bytes:
-        """Decode base64 bytes."""
-        return base64.b64decode(value, validate=True)
-
-
-Base64Bytes = Annotated[bytes, EncodedBytes(encoder=Base64EncoderSansNewline)]
 
 
 class Distribution(BaseModel):

--- a/test/test_impl.py
+++ b/test/test_impl.py
@@ -9,7 +9,7 @@ from typing import Any
 import pretend
 import pytest
 import sigstore
-from pydantic import BaseModel, TypeAdapter, ValidationError
+from pydantic import Base64Bytes, BaseModel, TypeAdapter, ValidationError
 from sigstore.dsse import DigestSet, StatementBuilder, Subject
 from sigstore.models import Bundle
 from sigstore.oidc import IdentityToken
@@ -614,18 +614,14 @@ class TestProvenance:
 
 
 class DummyModel(BaseModel):
-    base64_bytes: impl.Base64Bytes
+    base64_bytes: Base64Bytes
 
 
 class TestBase64Bytes:
-    # See the docstrings for `_impl.Base64Bytes` for more details
-    def test_decoding(self) -> None:
-        # This raises when using our custom type. When using Pydantic's Base64Bytes,
-        # this succeeds
-        # The exception message is different in Python 3.9 vs >=3.10
-        with pytest.raises(ValueError, match="Non-base64 digit found|Only base64 data is allowed"):
-            DummyModel(base64_bytes=b"a\n\naaa")
-
+    # Regression test for an issue with pydantic < 2.10.0
+    # The Base64Bytes Pydantic type should not insert newlines
+    # when encoding to base64.
+    # See https://github.com/pydantic/pydantic/issues/9072
     def test_encoding(self) -> None:
         model = DummyModel(base64_bytes=b"aaaa" * 76)
         assert "\\n" not in model.model_dump_json()


### PR DESCRIPTION
Now that `pydantic` 2.10.0 was released with the fix for https://github.com/pydantic/pydantic/issues/9072, this PR removes the workaround implemented in https://github.com/trailofbits/pypi-attestations/pull/48.

Relevant entry in the release notes: https://pydantic.dev/articles/pydantic-v2-10-release#use-b64decode-and-b64encode-for-base64bytes-and-base64str-types
