### PR TITLE
chore: prep 0.0.20

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.0.20]
+
+- Explicitly support sigstore-python 3.6.
+
 ## [0.0.19]
 
 This is a corrective release for [0.0.18].

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -209,7 +209,8 @@ This is a corrective release for [0.0.14].
 
 - Initial implementation
 
-[Unreleased]: https://github.com/trailofbits/pypi-attestation-models/compare/v0.0.19...HEAD
+[Unreleased]: https://github.com/trailofbits/pypi-attestation-models/compare/v0.0.20...HEAD
+[0.0.20]: https://github.com/trailofbits/pypi-attestation-models/compare/v0.0.19...v0.0.20
 [0.0.19]: https://github.com/trailofbits/pypi-attestation-models/compare/v0.0.18...v0.0.19
 [0.0.18]: https://github.com/trailofbits/pypi-attestation-models/compare/v0.0.17...v0.0.18
 [0.0.17]: https://github.com/trailofbits/pypi-attestation-models/compare/v0.0.16...v0.0.17

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.0.20]
 
+### Changed
+
 - Explicitly support sigstore-python 3.6
   ([#79](https://github.com/trailofbits/pypi-attestations/pull/79))
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.0.20]
 
-- Explicitly support sigstore-python 3.6.
+- Explicitly support sigstore-python 3.6
+  ([#79](https://github.com/trailofbits/pypi-attestations/pull/79))
 
 ## [0.0.19]
 

--- a/src/pypi_attestations/__init__.py
+++ b/src/pypi_attestations/__init__.py
@@ -1,6 +1,6 @@
 """The `pypi-attestations` APIs."""
 
-__version__ = "0.0.19"
+__version__ = "0.0.20"
 
 from ._impl import (
     Attestation,


### PR DESCRIPTION
Preps a release that supports sigstore-python 3.6.0.

Signed-off-by: William Woodruff <william@trailofbits.com>