### PR TITLE
Add `pypi-attestations verify pypi` CLI subcommand

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,14 +84,14 @@ print(bundle.to_json())
 ## Usage as a command line tool
 
 > [!IMPORTANT]
-> The `python -m pypi_attestations` CLI is intended primarily for
+> The `pypi-attestations` CLI is intended primarily for
 > experimentation, and is not considered a stable interface for
 > generating or verifying attestations. Users are encouraged to
 > generate attestations using [the official PyPA publishing action]
 > or via this package's [public Python APIs].
 
 ````bash
-python -m pypi_attestations --help
+pypi-attestations --help
 usage: pypi-attestation [-h] [-v] [-V] COMMAND ...
 
 Sign, inspect or verify PEP 740 attestations
@@ -119,7 +119,7 @@ options:
 ```bash
 # Generate a whl file
 make package
-python -m pypi_attestations sign dist/pypi_attestations-*.whl
+pypi-attestations sign dist/pypi_attestations-*.whl
 ```
 
 ### Inspecting a PEP 740 Attestation
@@ -129,7 +129,7 @@ python -m pypi_attestations sign dist/pypi_attestations-*.whl
 > the attestation.
 
 ```bash
-python -m pypi_attestations inspect dist/pypi_attestations-*.whl.publish.attestation
+pypi-attestations inspect dist/pypi_attestations-*.whl.publish.attestation
 ```
 
 ### Verifying a PEP 740 Attestation
@@ -140,7 +140,7 @@ python -m pypi_attestations inspect dist/pypi_attestations-*.whl.publish.attesta
 > workflow that generated the attestation. The format of that identity
 
 ```bash
-python -m pypi_attestations verify --staging \
+pypi-attestations verify --staging \
   --identity william@yossarian.net \
   test/assets/rfc8785-0.1.2-py3-none-any.whl
 ```

--- a/README.md
+++ b/README.md
@@ -140,13 +140,30 @@ pypi-attestations inspect dist/pypi_attestations-*.whl.publish.attestation
 > workflow that generated the attestation. The format of that identity
 
 ```bash
-pypi-attestations verify --staging \
+pypi-attestations verify attestation --staging \
   --identity william@yossarian.net \
   test/assets/rfc8785-0.1.2-py3-none-any.whl
 ```
 
 The attestation present in the test has been generated using the staging
 environment of Sigstore and signed by the identity `william@yossarian.net`.
+
+### Verifying a PyPI package
+> [!NOTE]
+> The URL must be a direct link to the distribution artifact hosted by PyPI.
+> These can be found in the "Download files" section of the project's page,
+> e.g: https://pypi.org/project/sigstore/#files
+
+```bash
+pypi-attestations verify pypi --repository https://github.com/sigstore/sigstore-python \
+  https://files.pythonhosted.org/packages/70/f5/324edb6a802438e97e289992a41f81bb7a58a1cda2e49439e7e48896649e/sigstore-3.6.1-py3-none-any.whl
+```
+
+This command downloads the artifact from the given URL and gets its provenance
+from PyPI. The artifact is then verified against the provenance, while also
+checking that the provenance's signing identity matches the repository specified
+by the user.
+
 
 [PEP 740]: https://peps.python.org/pep-0740/
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,7 +51,7 @@ name = "pypi_attestations"
 
 [tool.coverage.run]
 # don't attempt code coverage for the CLI entrypoints
-omit = ["src/pypi_attestations/_cli.py", "src/pypi_attestations/__main__.py"]
+omit = ["src/pypi_attestations/__main__.py"]
 
 [tool.mypy]
 mypy_path = "src"
@@ -104,7 +104,6 @@ pyupgrade.keep-runtime-typing = true
 exclude = [
     "env",
     "test",
-    "src/pypi_attestations/_cli.py",
     "src/pypi_attestations/__main__.py",
 ]
 ignore-semiprivate = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,7 @@ test = ["pytest", "pytest-cov", "pretend", "coverage[toml]"]
 lint = [
     # NOTE: ruff is under active development, so we pin conservatively here
     # and let Dependabot periodically perform this update.
-    "ruff ~= 0.2",
+    "ruff ~= 0.9",
     "mypy >= 1.0",
     "types-html5lib",
     "types-requests",
@@ -82,11 +82,10 @@ target-version = "py39"
 
 [tool.ruff.lint]
 select = ["E", "F", "I", "W", "UP", "ANN", "D", "COM", "ISC", "TCH", "SLF"]
-# ANN101 and ANN102 are deprecated
 # D203 and D213 are incompatible with D211 and D212 respectively.
 # COM812 and ISC001 can cause conflicts when using ruff as a formatter.
 # See https://docs.astral.sh/ruff/formatter/#conflicting-lint-rules.
-ignore = ["ANN101", "ANN102", "D203", "D213", "COM812", "ISC001"]
+ignore = ["D203", "D213", "COM812", "ISC001"]
 # Needed since Pydantic relies on runtime type annotations, and we target Python versions
 # < 3.10. See https://docs.astral.sh/ruff/rules/non-pep604-annotation/#why-is-this-bad
 pyupgrade.keep-runtime-typing = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,6 +39,8 @@ lint = [
 ]
 dev = ["pypi-attestations[doc,test,lint]", "build"]
 
+[project.scripts]
+pypi-attestations = "pypi_attestations._cli:main"
 
 [project.urls]
 Homepage = "https://pypi.org/project/pypi-attestations"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,6 +14,8 @@ dependencies = [
     "packaging",
     "pyasn1 ~= 0.6",
     "pydantic >= 2.10.0",
+    "requests",
+    "rfc3986",
     "sigstore >= 3.5.3, < 3.7",
     "sigstore-protobuf-specs",
 ]

--- a/src/pypi_attestations/_cli.py
+++ b/src/pypi_attestations/_cli.py
@@ -385,7 +385,7 @@ def _verify_attestation(args: argparse.Namespace) -> None:
     """Verify the files passed as argument."""
     pol = policy.Identity(identity=args.identity)
 
-    # Validate that both the attestations and files exists
+    # Validate that both the attestations and files exist
     _validate_files(args.files, should_exist=True)
     _validate_files(
         (Path(f"{file_path}.publish.attestation") for file_path in args.files),
@@ -394,15 +394,7 @@ def _verify_attestation(args: argparse.Namespace) -> None:
 
     inputs: list[Path] = []
     for file_path in args.files:
-        # Collect only the inputs themselves, not their attestations.
-        # Attestation paths are inferred subsequently.
-        if file_path.name.endswith(".publish.attestation"):
-            _logger.warning(f"skipping attestation path while collecting file inputs: {file_path}")
-            continue
         inputs.append(file_path)
-
-    if not inputs:
-        _die("No inputs given; make sure you passed distributions and not attestations as inputs")
 
     for input in inputs:
         attestation_path = Path(f"{input}.publish.attestation")

--- a/src/pypi_attestations/_cli.py
+++ b/src/pypi_attestations/_cli.py
@@ -37,7 +37,7 @@ def _parser() -> argparse.ArgumentParser:
     )
 
     parser = argparse.ArgumentParser(
-        prog="python -m pypi_attestations",
+        prog="pypi-attestations",
         description="Sign, inspect or verify PEP 740 attestations",
         parents=[parent_parser],
         formatter_class=argparse.ArgumentDefaultsHelpFormatter,


### PR DESCRIPTION
The `verify` CLI subcommand is now split into two:
- `verify attestation`, which behaves as the previous `verify` command (verifies an artifact and its corresponding PEP740 attestation)
- `verify pypi`, which takes the URL of a distribution hosted on PyPI and a signing identity and verifies them.

Examples:
```sh
$ pypi-attestations verify pypi https://files.pythonhosted.org/packages/f0/d5/1341f23a51e45b7780ed6e0b1df3efc9ec4350a528b3f15ec83146edd6ab/abi3info-2025.1.9-py3-none-any.whl --repository https://gitlab.com/woodruffw/abi3info
Verification failed: provenance was signed by a github.com repository, but expected a gitlab.com repository

$ pypi-attestations verify pypi https://files.pythonhosted.org/packages/f0/d5/1341f23a51e45b7780ed6e0b1df3efc9ec4350a528b3f15ec83146edd6ab/abi3info-2025.1.9-py3-none-any.whl --repository https://github.com/evil/abi3info
Verification failed: provenance was signed by repository "woodruffw/abi3info", expected "evil/abi3info"

$ pypi-attestations verify pypi https://files.pythonhosted.org/packages/f0/d5/1341f23a51e45b7780ed6e0b1df3efc9ec4350a528b3f15ec83146edd6ab/abi3info-2025.1.9-py3-none-any.whl --repository https://github.com/woodruffw/abi3info
OK: abi3info-2025.1.9-py3-none-any.whl
```

See https://github.com/sigstore/sigstore-python/issues/1271 for context