### PR TITLE
cli: Support friendlier syntax for `verify pypi` command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - The CLI subcommand `verify attestation` now supports `.slsa.attestation`
   files. When verifying an artifact, both `.publish.attestation` and
   `.slsa.attestation` files are used (if present).
+- The CLI subcommand `verify attestation` now supports a friendlier
+  syntax to specify the artifact to verify. The artifact can now be
+  specified as `$PKG_NAME/$FILE_NAME`, e.g: 
+  `sampleproject/sampleproject-1.0.0.tar.gz`. The old way (passing
+  the direct URL) is still supported.
 
 ## [0.0.21]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,10 +12,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - The CLI subcommand `verify attestation` now supports `.slsa.attestation`
   files. When verifying an artifact, both `.publish.attestation` and
   `.slsa.attestation` files are used (if present).
-- The CLI subcommand `verify attestation` now supports a friendlier
+- The CLI subcommand `verify pypi` now supports a friendlier
   syntax to specify the artifact to verify. The artifact can now be
-  specified as `$PKG_NAME/$FILE_NAME`, e.g: 
-  `sampleproject/sampleproject-1.0.0.tar.gz`. The old way (passing
+  specified with a `pypi:` prefix followed by the filename, e.g:
+  `pypi:sampleproject-1.0.0.tar.gz`. The old way (passing
   the direct URL) is still supported.
 
 ## [0.0.21]

--- a/README.md
+++ b/README.md
@@ -142,12 +142,12 @@ pypi-attestations verify attestation  \
 
 ### Verifying a PyPI package
 > [!NOTE]
-> The package to verify can be passed either as $PKG_NAME/$FILE_NAME (e.g:
-> 'sampleproject/sampleproject-1.0.0-py3-none-any.whl'), or as a direct URL
+> The package to verify can be passed either as a `pypi:` prefixed filename (e.g:
+> 'pypi:sampleproject-1.0.0-py3-none-any.whl'), or as a direct URL
 > to the artifact hosted by PyPI.
 ```bash
 pypi-attestations verify pypi --repository https://github.com/sigstore/sigstore-python \
-  sigstore/sigstore-3.6.1-py3-none-any.whl
+  pypi:sigstore-3.6.1-py3-none-any.whl
 
 # or alternatively:
 pypi-attestations verify pypi --repository https://github.com/sigstore/sigstore-python \

--- a/README.md
+++ b/README.md
@@ -142,19 +142,21 @@ pypi-attestations verify attestation  \
 
 ### Verifying a PyPI package
 > [!NOTE]
-> The URL must be a direct link to the distribution artifact hosted by PyPI.
-> These can be found in the "Download files" section of the project's page,
-> e.g: https://pypi.org/project/sigstore/#files
-
+> The package to verify can be passed either as $PKG_NAME/$FILE_NAME (e.g:
+> 'sampleproject/sampleproject-1.0.0-py3-none-any.whl'), or as a direct URL
+> to the artifact hosted by PyPI.
 ```bash
+pypi-attestations verify pypi --repository https://github.com/sigstore/sigstore-python \
+  sigstore/sigstore-3.6.1-py3-none-any.whl
+
+# or alternatively:
 pypi-attestations verify pypi --repository https://github.com/sigstore/sigstore-python \
   https://files.pythonhosted.org/packages/70/f5/324edb6a802438e97e289992a41f81bb7a58a1cda2e49439e7e48896649e/sigstore-3.6.1-py3-none-any.whl
 ```
 
-This command downloads the artifact from the given URL and gets its provenance
-from PyPI. The artifact is then verified against the provenance, while also
-checking that the provenance's signing identity matches the repository specified
-by the user.
+This command downloads the artifact and its provenance from PyPI. The artifact 
+is then verified against the provenance, while also checking that the provenance's 
+signing identity matches the repository specified by the user.
 
 
 [PEP 740]: https://peps.python.org/pep-0740/


### PR DESCRIPTION
Rather than specify the full `pythonhosted.org` url for artifacts, now `verify pypi` also supports the friendlier syntax `$PKG_NAME/$FILE_NAME`

```
pypi-attestations verify pypi --repository https://github.com/sigstore/sigstore-python \
  sigstore/sigstore-3.6.1-py3-none-any.whl
```

This fixes https://github.com/trailofbits/pypi-attestations/issues/84