### PR TITLE
_cli: `make reformat`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- The `inspect` subcommand now ignores inputs that don't match `*.attestation`,
+  rather than failing on them
+  ([#93](https://github.com/trailofbits/pypi-attestations/pull/93))
+
 ### Added
 
 - The CLI subcommand `verify attestation` now supports `.slsa.attestation`
@@ -22,7 +28,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- The CLI entrypoint is now `pypi-attestations` 
+- The CLI entrypoint is now `pypi-attestations`
   ([#82](https://github.com/trailofbits/pypi-attestations/pull/82))
 - The CLI `verify` subcommand has been changed to `verify attestation`,
   as in `pypi-attestations verify attestation --identity ...`

--- a/src/pypi_attestations/_cli.py
+++ b/src/pypi_attestations/_cli.py
@@ -390,7 +390,7 @@ def _inspect(args: argparse.Namespace) -> None:
 
     Warning: The information displayed from the attestations are not verified.
     """
-    attestation_files = [f for f in args.files if f.suffix == '.attestation']
+    attestation_files = [f for f in args.files if f.suffix == ".attestation"]
     _validate_files(attestation_files, should_exist=True)
     for file_path in attestation_files:
         try:

--- a/test/test_cli.py
+++ b/test/test_cli.py
@@ -194,19 +194,6 @@ def test_inspect_command(caplog: pytest.LogCaptureFixture) -> None:
     run_main_with_command(["inspect", "--dump-bytes", publish_attestation_path.as_posix()])
     assert "Signature:" in caplog.text
 
-    # Failure paths
-    caplog.clear()
-
-    # Failure because not an attestation
-    with tempfile.NamedTemporaryFile(suffix=".publish.attestation") as f:
-        fake_package_name = Path(f.name.removesuffix(".publish.attestation"))
-        fake_package_name.touch()
-
-        with pytest.raises(SystemExit):
-            run_main_with_command(["inspect", fake_package_name.as_posix()])
-
-        assert "Invalid attestation" in caplog.text
-
 
 def test_verify_attestation_command(caplog: pytest.LogCaptureFixture) -> None:
     # Happy path

--- a/test/test_cli.py
+++ b/test/test_cli.py
@@ -207,13 +207,6 @@ def test_inspect_command(caplog: pytest.LogCaptureFixture) -> None:
 
         assert "Invalid attestation" in caplog.text
 
-    # Failure because file is missing
-    caplog.clear()
-    with pytest.raises(SystemExit):
-        run_main_with_command(["inspect", "not_a_file.txt"])
-
-    assert "not_a_file.txt is not a file." in caplog.text
-
 
 def test_verify_attestation_command(caplog: pytest.LogCaptureFixture) -> None:
     # Happy path

--- a/test/test_cli.py
+++ b/test/test_cli.py
@@ -194,6 +194,19 @@ def test_inspect_command(caplog: pytest.LogCaptureFixture) -> None:
     run_main_with_command(["inspect", "--dump-bytes", publish_attestation_path.as_posix()])
     assert "Signature:" in caplog.text
 
+    # Failure paths
+    caplog.clear()
+
+    # Failure because not an attestation
+    with tempfile.NamedTemporaryFile(suffix=".publish.attestation") as f:
+        f.write(b"not an attestation")
+        f.flush()
+
+        with pytest.raises(SystemExit):
+            run_main_with_command(["inspect", f.name])
+
+        assert "Invalid attestation" in caplog.text
+
 
 def test_verify_attestation_command(caplog: pytest.LogCaptureFixture) -> None:
     # Happy path


### PR DESCRIPTION
Fixes some CI failures + updates the tests to reflect the new `inspect` behavior (non-matching filenames are now ignored rather than treated as failures).