### PR TITLE
build: Add the missing `build-system` section to fix building

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,7 @@
+[build-system]
+requires = ["setuptools"]
+build-backend = "setuptools.build_meta"
+
 [project]
 name = "pypi-attestations"
 dynamic = ["version"]


### PR DESCRIPTION
Add the missing `build-system` section to fix compatibility with strict PEP 517 installers.  Per PEP 517, projects are required to either specify a backend explicitly *or* (for compatibility with legacy projects) provide a `setup.py` file.