### PR TITLE
build: Include `conftest.py` and test assets in source distribution

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,2 @@
+include test/*.py
+graft test/assets


### PR DESCRIPTION
Include the `conftest.py` file and test assets in the source distribution archives explicitly.  Otherwise, only `test_*.py` files are included, and they are insufficient to run tests.