### PR TITLE
refactor: drop sigstore-protobuf-specs dependency

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -10,8 +10,8 @@ permissions: {}
 
 env:
   FORCE_COLOR: "1"
-  PYTHONDEVMODE: "1"  # -X dev
-  PYTHONWARNDEFAULTENCODING: "1"  # -X warn_default_encoding
+  PYTHONDEVMODE: "1" # -X dev
+  PYTHONWARNDEFAULTENCODING: "1" # -X warn_default_encoding
 
 jobs:
   test:
@@ -24,8 +24,6 @@ jobs:
           - "3.12"
           - "3.13"
     runs-on: ubuntu-latest
-    permissions:
-      id-token: write  # unit tests use the ambient OIDC credential
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
@@ -40,6 +38,10 @@ jobs:
 
       - name: test
         run: make test INSTALL_EXTRA=test
+        env:
+          # Use the pubic OIDC beacon for online tests, rather than relying
+          # on the workflow's own ID token.
+          EXTREMELY_DANGEROUS_PUBLIC_OIDC_BEACON: 1
 
   test-offline:
     runs-on: ubuntu-latest

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,9 +10,7 @@ readme = "README.md"
 license = "Apache-2.0"
 license-files = ["LICENSE"]
 authors = [{ name = "Trail of Bits", email = "opensource@trailofbits.com" }]
-classifiers = [
-    "Programming Language :: Python :: 3",
-]
+classifiers = ["Programming Language :: Python :: 3"]
 dependencies = [
     "cryptography",
     "packaging",
@@ -20,8 +18,8 @@ dependencies = [
     "pydantic >= 2.10.0",
     "requests",
     "rfc3986",
-    "sigstore >= 3.5.3, < 3.7",
-    "sigstore-protobuf-specs",
+    "sigstore @ git+https://github.com/sigstore/sigstore-python.git@ww/rm-protobufs",
+    "sigstore-models",
 ]
 requires-python = ">=3.9"
 
@@ -108,10 +106,6 @@ pyupgrade.keep-runtime-typing = true
 [tool.interrogate]
 # don't enforce documentation coverage for packaging, testing, the virtual
 # environment, or the CLI (which is documented separately).
-exclude = [
-    "env",
-    "test",
-    "src/pypi_attestations/__main__.py",
-]
+exclude = ["env", "test", "src/pypi_attestations/__main__.py"]
 ignore-semiprivate = true
 fail-under = 100

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -11,5 +11,14 @@ def id_token() -> oidc.IdentityToken:
         if token is None:
             pytest.fail("misconfigured CI: no ambient OIDC credential")
         return oidc.IdentityToken(token)
+    elif "EXTREMELY_DANGEROUS_PUBLIC_OIDC_BEACON" in os.environ:
+        import requests
+
+        resp = requests.get(
+            "https://raw.githubusercontent.com/sigstore-conformance/extremely-dangerous-public-oidc-beacon/refs/heads/current-token/oidc-token.txt"
+        )
+        resp.raise_for_status()
+        id_token = resp.text.strip()
+        return oidc.IdentityToken(id_token)
     else:
-        return oidc.Issuer.staging().identity_token()
+        return oidc.Issuer("https://oauth2.sigstage.dev/auth").identity_token()

--- a/test/test_cli.py
+++ b/test/test_cli.py
@@ -12,7 +12,7 @@ import pytest
 import requests
 import sigstore.oidc
 from pretend import raiser, stub
-from sigstore.oidc import IdentityError
+from sigstore.oidc import IdentityError, IdentityToken
 
 import pypi_attestations._cli
 from pypi_attestations._cli import (
@@ -75,7 +75,9 @@ def test_main_verbose_level(monkeypatch: pytest.MonkeyPatch) -> None:
 
 
 @online
-def test_get_identity_token(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_get_identity_token(id_token: IdentityToken, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(sigstore.oidc, "detect_credential", lambda: id_token._raw_token)
+
     # Happy paths
     identity_token = get_identity_token(argparse.Namespace(staging=True))
     assert identity_token.in_validity_period()
@@ -92,7 +94,11 @@ def test_get_identity_token(monkeypatch: pytest.MonkeyPatch) -> None:
 
 
 @online
-def test_sign_command(tmp_path: Path) -> None:
+def test_sign_command(
+    id_token: IdentityToken, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setattr(sigstore.oidc, "detect_credential", lambda: id_token._raw_token)
+
     # Happy path
     copied_artifact = tmp_path / artifact_path.name
     shutil.copy(artifact_path, copied_artifact)
@@ -112,7 +118,11 @@ def test_sign_command(tmp_path: Path) -> None:
 
 
 @online
-def test_sign_missing_file(caplog: pytest.LogCaptureFixture) -> None:
+def test_sign_missing_file(
+    id_token: IdentityToken, caplog: pytest.LogCaptureFixture, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setattr(sigstore.oidc, "detect_credential", lambda: id_token._raw_token)
+
     # Missing file
     with pytest.raises(SystemExit):
         run_main_with_command(
@@ -127,7 +137,14 @@ def test_sign_missing_file(caplog: pytest.LogCaptureFixture) -> None:
 
 
 @online
-def test_sign_signature_already_exists(tmp_path: Path, caplog: pytest.LogCaptureFixture) -> None:
+def test_sign_signature_already_exists(
+    id_token: IdentityToken,
+    tmp_path: Path,
+    caplog: pytest.LogCaptureFixture,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(sigstore.oidc, "detect_credential", lambda: id_token._raw_token)
+
     artifact = tmp_path / artifact_path.with_suffix(".copy2.whl").name
     artifact.touch(exist_ok=False)
 
@@ -168,7 +185,14 @@ def test_sign_invalid_token(
 
 
 @online
-def test_sign_invalid_artifact(caplog: pytest.LogCaptureFixture, tmp_path: Path) -> None:
+def test_sign_invalid_artifact(
+    id_token: IdentityToken,
+    caplog: pytest.LogCaptureFixture,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(sigstore.oidc, "detect_credential", lambda: id_token._raw_token)
+
     artifact = tmp_path / "pkg-1.0.0.exe"
     artifact.touch(exist_ok=False)
 
@@ -180,8 +204,12 @@ def test_sign_invalid_artifact(caplog: pytest.LogCaptureFixture, tmp_path: Path)
 
 @online
 def test_sign_fail_to_sign(
-    monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture, tmp_path: Path
+    id_token: IdentityToken,
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+    tmp_path: Path,
 ) -> None:
+    monkeypatch.setattr(sigstore.oidc, "detect_credential", lambda: id_token._raw_token)
     monkeypatch.setattr(pypi_attestations._cli, "Attestation", stub(sign=raiser(AttestationError)))
     copied_artifact = tmp_path / artifact_path.name
     shutil.copy(artifact_path, copied_artifact)
@@ -329,19 +357,22 @@ def test_verify_attestation_invalid_artifact(
     assert "Invalid Python package distribution" in caplog.text
 
 
-def test_get_identity_token_oauth_flow(monkeypatch: pytest.MonkeyPatch) -> None:
+@pytest.mark.parametrize("staging", [True, False])
+def test_get_identity_token_oauth_flow(staging: bool, monkeypatch: pytest.MonkeyPatch) -> None:
     # If no ambient credential is available, default to the OAuth2 flow
     monkeypatch.setattr(sigstore.oidc, "detect_credential", lambda: None)
     identity_token = stub()
 
     class MockIssuer:
-        @staticmethod
-        def staging() -> stub:
-            return stub(identity_token=lambda: identity_token)
+        def __init__(self, *args: object, **kwargs: object) -> None:
+            pass
+
+        def identity_token(self) -> sigstore.oidc.IdentityToken:
+            return identity_token  # type: ignore
 
     monkeypatch.setattr(pypi_attestations._cli, "Issuer", MockIssuer)
 
-    assert pypi_attestations._cli.get_identity_token(stub(staging=True)) == identity_token
+    assert pypi_attestations._cli.get_identity_token(stub(staging=staging)) == identity_token
 
 
 def test_validate_files(tmp_path: Path, caplog: pytest.LogCaptureFixture) -> None:

--- a/test/test_impl.py
+++ b/test/test_impl.py
@@ -14,6 +14,7 @@ from cryptography import x509
 from cryptography.hazmat.primitives import hashes
 from cryptography.hazmat.primitives.asymmetric import ec
 from pydantic import Base64Bytes, BaseModel, TypeAdapter, ValidationError
+from sigstore._internal.trust import ClientTrustConfig
 from sigstore.dsse import DigestSet, StatementBuilder, Subject
 from sigstore.models import Bundle
 from sigstore.oidc import IdentityToken
@@ -69,7 +70,8 @@ class TestDistribution:
 class TestAttestation:
     @online
     def test_roundtrip(self, id_token: IdentityToken) -> None:
-        sign_ctx = SigningContext.staging()
+        trust_config = ClientTrustConfig.staging()
+        sign_ctx = SigningContext.from_trust_config(trust_config)
 
         with sign_ctx.signer(id_token) as signer:
             attestation = impl.Attestation.sign(signer, dist)
@@ -103,7 +105,9 @@ class TestAttestation:
 
         monkeypatch.setattr(IdentityToken, "in_validity_period", in_validity_period)
 
-        sign_ctx = SigningContext.staging()
+        trust_config = ClientTrustConfig.staging()
+        sign_ctx = SigningContext.from_trust_config(trust_config)
+
         with sign_ctx.signer(id_token, cache=False) as signer:
             with pytest.raises(impl.AttestationError):
                 impl.Attestation.sign(signer, dist)
@@ -120,7 +124,8 @@ class TestAttestation:
 
         monkeypatch.setattr(sigstore.sign.Signer, "sign_dsse", get_bundle)
 
-        sign_ctx = SigningContext.staging()
+        trust_config = ClientTrustConfig.staging()
+        sign_ctx = SigningContext.from_trust_config(trust_config)
 
         with pytest.raises(impl.AttestationError):
             with sign_ctx.signer(id_token) as signer:
@@ -485,6 +490,14 @@ class TestAttestation:
         assert subject_name != dist.name
 
 
+def test_from_bundle_not_dsse() -> None:
+    bundle = Bundle.from_json(dist_bundle_path.read_bytes())
+    bundle._inner.dsse_envelope = None
+
+    with pytest.raises(impl.ConversionError, match="bundle does not contain a DSSE envelope"):
+        impl.Attestation.from_bundle(bundle)
+
+
 def test_from_bundle_missing_signatures() -> None:
     bundle = Bundle.from_json(dist_bundle_path.read_bytes())
     bundle._inner.dsse_envelope.signatures = []  # noqa: SLF001
@@ -724,8 +737,8 @@ class TestGitHubPublisher:
             .issuer_name(orig_cert.issuer)
             .public_key(orig_cert.public_key())
             .serial_number(orig_cert.serial_number)
-            .not_valid_before(orig_cert.not_valid_before)
-            .not_valid_after(orig_cert.not_valid_after)
+            .not_valid_before(orig_cert.not_valid_before_utc)
+            .not_valid_after(orig_cert.not_valid_after_utc)
         )
 
         for ext in orig_cert.extensions:

--- a/test/test_impl.py
+++ b/test/test_impl.py
@@ -119,7 +119,7 @@ class TestAttestation:
         def get_bundle(*_: Any) -> Bundle:
             # Duplicate the signature to trigger a Conversion error
             bundle = Bundle.from_json(gh_signed_dist_bundle_path.read_bytes())
-            bundle._inner.dsse_envelope.signatures.append(bundle._inner.dsse_envelope.signatures[0])
+            bundle._inner.dsse_envelope.signatures.append(bundle._inner.dsse_envelope.signatures[0])  # type: ignore[union-attr]
             return bundle
 
         monkeypatch.setattr(sigstore.sign.Signer, "sign_dsse", get_bundle)
@@ -500,7 +500,7 @@ def test_from_bundle_not_dsse() -> None:
 
 def test_from_bundle_missing_signatures() -> None:
     bundle = Bundle.from_json(dist_bundle_path.read_bytes())
-    bundle._inner.dsse_envelope.signatures = []  # noqa: SLF001
+    bundle._inner.dsse_envelope.signatures = []  # type: ignore # noqa: SLF001
 
     with pytest.raises(impl.ConversionError, match="expected exactly one signature, got 0"):
         impl.Attestation.from_bundle(bundle)


### PR DESCRIPTION
I come bearing gifts 🙂 

This is a work in progress; it shouldn't be merged until https://github.com/sigstore/sigstore-python/pull/1470 lands in a release.

Key changes:

* `sigstore-protobuf-specs` is entirely gone.
* I've refactored the tests to use the public OIDC beacon, and made some corresponding tweaks to the CI to use the beacon by default. This allows tests to run with 100% coverage, even on third-party PRs (like this one).

Closes #131.
